### PR TITLE
Add github support

### DIFF
--- a/bin/findRepo
+++ b/bin/findRepo
@@ -1,4 +1,4 @@
-#! ruby
+#!/usr/bin/env ruby
 
 # Imports
 ###############################################################################
@@ -11,11 +11,21 @@ require 'uri'
 
 # Helper function
 ###############################################################################
-def get_repo_from_gitlab_json(json, search_name)
+def download_json(uri)
+  begin
+    res = open(uri.to_s)
+    return JSON.parse(res.read)
+
+  rescue OpenURI::HTTPError
+    return nil
+  end
+end
+
+def get_repo_from_json(json, search_name, repo_property_name)
   json.each do |repo|
     if repo['name'].downcase == search_name
-      puts repo['ssh_url_to_repo']
-      exit 0  # Stop execution if repo is found
+        puts repo[repo_property_name]
+        exit 0 # Stop execution if repo is found
     end
   end
 end
@@ -28,13 +38,16 @@ def get_gitlab_projects_json(repo, search_name)
     :query => querystring
     })
 
-  begin
-    res = open(uri.to_s)
-    return JSON.parse(res.read)
+  download_json(uri)
+end
 
-  rescue OpenURI::HTTPError
-    return nil
-  end
+def get_github_projects_json(repo, search_name)
+  uri = URI::HTTPS.build({
+    :host => 'api.github.com',
+    :path => '/users/' << repo['username'] << '/repos'
+    })
+
+  download_json(uri)
 end
 
 def read_config
@@ -58,10 +71,11 @@ search_term = ARGV[0].downcase
 yaml_config['repositories'].each do |repo|
   if repo['type'] == 'gitlab'
     gitlab_json = get_gitlab_projects_json(repo, search_term)
-    get_repo_from_gitlab_json(gitlab_json, search_term) if gitlab_json
+    get_repo_from_json(gitlab_json, search_term, 'ssh_url_to_repo') if gitlab_json
 
   elsif repo['type'] == 'github'
-    # TODO: add github support
+    github_json = get_github_projects_json(repo, search_term)
+    get_repo_from_json(github_json, search_term, 'ssh_url') if github_json
   end
 end
 


### PR DESCRIPTION
Based on the existing code for gitlab, add new functionality to
search github profiles for repositories. The code has been
refactored a little. A new download_json and get_repo_from_json
function have been introduced to implement functionality needed
for both gitlab and github. Also the shebang was changed to make
this run on my linux box.

Example yaml config for github profile:

repositories:
    - type: 'github'
      username: 'HerrSubset'